### PR TITLE
CRLFが混じる可能性をなくす

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
windows環境でのCIでformatが失敗する。改行コードがCRLFになってしまうため。